### PR TITLE
Add async GraphQLView wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # async-graphene-django
 A drop-in extension for graphene-django that enables fully async GraphQL execution. This package provides an AsyncGraphQLView and integrates Django's async capabilities to support modern asynchronous resolvers, improving performance and compatibility with async-based backends.
+
+## 中文文档
+
+此项目提供 `AsyncGraphQLView`，用于將 `graphene-django` 的 `GraphQLView` 完全异步化。
+只需在 `urls.py` 中引用此类即可享受异步解析带来的性能优势。
+
+```python
+from async_graphql_view import AsyncGraphQLView
+
+urlpatterns = [
+    path("graphql/", AsyncGraphQLView.as_view(graphiql=True)),
+]
+```

--- a/async_graphql_view.py
+++ b/async_graphql_view.py
@@ -1,0 +1,34 @@
+"""Async wrapper for graphene-django's GraphQLView."""
+
+from typing import Optional
+
+from graphene_django.views import GraphQLView
+from graphql import ExecutionResult
+
+
+class AsyncGraphQLView(GraphQLView):
+    """GraphQLView with asynchronous execution of queries."""
+
+    async def execute_graphql_request(
+        self,
+        request,
+        data,
+        query: str,
+        variables: Optional[dict] = None,
+        operation_name: Optional[str] = None,
+        show_graphiql: bool = False,
+    ) -> Optional[ExecutionResult]:
+        if not query:
+            return None
+
+        context = self.get_context(request)
+        middleware = self.get_middleware(request)
+
+        return await self.schema.execute_async(
+            query,
+            variables=variables,
+            operation_name=operation_name,
+            context_value=context,
+            middleware=middleware,
+            root_value=self.get_root_value(request),
+        )


### PR DESCRIPTION
## Summary
- add an `AsyncGraphQLView` wrapper implementing async `execute_graphql_request`
- document the usage in Chinese

## Testing
- `python -m py_compile async_graphql_view.py`

------
https://chatgpt.com/codex/tasks/task_e_68694663544083219124fbf65d11dc32